### PR TITLE
Systemd service + configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,35 @@ You should ensure that this script runs all the time. The easiest way would be t
         test.example.com 5 Z148QEXAMPLE8V 30 2>&1 | logger -t awsdyndns --id=$$ &
 ```
 
+# Installing aws-dyndns as a systemd service
+Running aws-dyndns as a systemd service will start the service boot, manage logging,
+execute with the least possible permissions, and relaunch on crash.
+
+```bash
+# These commands are relative to the project root. Change directories to get there.
+cd aws-dyndns
+
+# This will launch the default editor, so you can set a configuration.
+# Because this will run as the unprivileged nobody/nogroup user/group we need to pass the AWS credentials.
+editor systemd/aws-dyndns.conf
+
+# The configuration file needs to be readable by root, but we can give it very restrictive permissions to protect our AWS key.
+sudo chown root:root aws-dyndns systemd/aws-dyndns.service systemd/aws-dyndns.conf 
+sudo chmod 600 systemd/aws-dyndns.conf
+
+# Install the executable, configuration, and service
+sudo mv aws-dyndns /usr/local/sbin
+sudo mv systemd/aws-dyndns.conf /etc/
+sudo mv systemd/aws-dyndns.service /etc/systemd/system
+
+# Reload systemd and then start the service.
+sudo systemctl daemon-reload
+sudo systemctl start aws-dyndns
+
+# Check the log to make sure everything started as expected.
+tail -n 20 /var/log/syslog
+```
+
 # Sample log output
 
 ```

--- a/systemd/aws-dyndns.conf
+++ b/systemd/aws-dyndns.conf
@@ -1,0 +1,19 @@
+# All parameters in this file are required.
+
+# The AWS access key id is the shorter value (20 characters).
+AWS_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXXXX
+
+# The AWS secret access key is the longer value, and is more private.
+AWS_SECRET_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# The hostname we wish to update with our public IP.
+UPDATE_DNS_FQDN=home.example.com
+
+# The AWS Route 53 Zone ID
+UPDATE_AWS_ZONE_ID=XXXXXXXXXXXXXX
+
+# DNS TTL - The number of seconds an end-device will cache the record before checking with AWS again.
+UPDATE_DNS_TTL=5
+
+# The frequency which aws-dyndns will chech the address and update Route 53.
+UPDATE_RECHECK_SECS=30

--- a/systemd/aws-dyndns.service
+++ b/systemd/aws-dyndns.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=AWS Route53 Dynamic DNS
+After=network.target
+
+[Service]
+ExecStart=/usr/local/sbin/aws-dyndns $UPDATE_DNS_FQDN $UPDATE_DNS_TTL $UPDATE_AWS_ZONE_ID $UPDATE_RECHECK_SECS
+Type=simple
+User=nobody
+Group=nogroup
+EnvironmentFile=/etc/aws-dyndns.conf
+
+[Install]
+WantedBy=default.target
+


### PR DESCRIPTION
This commit adds a systemd.service file and an associated configuration file.  All of the configuration is done via an EnvironmentFile loaded by the systemd service.  The service is configured to run as nobody/nogroup, the unprivileged user/group combo on most systems.  AWS credentials are passed through the EnvironmentFile, which is read by root before the privileges are dropped.

It also adds documentation of the feature into the README.  